### PR TITLE
fix: improve logic of strict mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -57,7 +57,7 @@ const server = require('./server')
 global.port = config.port
 global.proxy = config.proxyUrl ? parse(config.proxyUrl) : null
 global.hosts = {}, hook.target.host.forEach(host => global.hosts[host] = config.forceHost)
-config.strict ? server.whitelist = ['music.163.com', 'music.126.net', 'vod.126.net'] : server.blanklist = []
+config.strict ? server.whitelist = ['music.163.com', 'music.126.net', 'vod.126.net', 'localhost'] : server.blacklist = []
 server.authentication = config.token || null
 global.endpoint = config.endpoint
 

--- a/server.js
+++ b/server.js
@@ -75,7 +75,7 @@ const proxy = {
 				let allow = server.whitelist.some(match)
 				let deny = server.blacklist.some(match)
 				// console.log('allow', allow, 'deny', deny)
-				if(!allow && deny){
+				if(!allow || deny){
 					return Promise.reject(ctx.error = 'filter')
 				}
 			}
@@ -171,7 +171,7 @@ const server = {
 }
 
 server.whitelist = ['.*']
-server.blacklist = ['.*']
+server.blacklist = []
 server.authentication = null
 
 module.exports = server


### PR DESCRIPTION
There was a typo of `server.blacklist`, and the logic of strict mode doesn't work when I connect via Quantumult. Now it is working with all my devices.

Fixes nondanee/UnblockNeteaseMusic#72