### PR TITLE
若歌曲是试听版本则匹配到其他音源

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -254,7 +254,7 @@ const tryMatch = ctx => {
 
 	const inject = item => {
 		item.flag = 0
-		if((item.code != 200 || item.freeTrialInfo !== null) && (target == 0 || item.id == target)){
+		if((item.code != 200 || item.freeTrialInfo) && (target == 0 || item.id == target)){
 			return match(item.id)
 			.then(song => {
 				item.url = `${global.endpoint || 'http://music.163.com'}/package/${crypto.base64.encode(song.url)}/${item.id}.mp3`

--- a/hook.js
+++ b/hook.js
@@ -254,7 +254,7 @@ const tryMatch = ctx => {
 
 	const inject = item => {
 		item.flag = 0
-		if(item.code != 200 && (target == 0 || item.id == target)){
+		if((item.code != 200 || item.freeTrialInfo !== null) && (target == 0 || item.id == target)){
 			return match(item.id)
 			.then(song => {
 				item.url = `${global.endpoint || 'http://music.163.com'}/package/${crypto.base64.encode(song.url)}/${item.id}.mp3`


### PR DESCRIPTION
在iOS平台上，有些VIP歌曲会提供可播放的网易地址，但是限制为30秒试听版本。这里修改代码以致若分辨为试听版本则启用匹配功能。

受影响歌曲如：
https://music.163.com/#/song?id=362998
https://music.163.com/#/song?id=28773682