### PR TITLE
Use CMD to allow argument passing in instance/加入CMD，直接拉起容器

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,4 @@ COPY . .
 EXPOSE 8080 8081
 
 ENTRYPOINT ["node", "app.js"]
+CMD

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ checknetisolation loopbackexempt -a -n="1F8B0F94.122165AE053F_j2p0p5q0044a6"
 
 > 使用此方法必须监听 80 端口 `-p 80` 
 >
-> **若在本机运行程序**，请指定网易云服务器 IP `-f xxx.xxx.xxx.xxx` (可在修改 hosts 前通过 `ping music.163.com` 获得) **或** 使用代理 `-u http(s)://xxx.xxx.xxx.xxx:xxx`，以防请求死循环
+> **若在本机运行程序**，请指定网易云服务器 IP `-f xxx.xxx.xxx.xxx` (可在修改 hosts 前通过 `ping music.163.com` 获得) **或** 使用代理 `-u http(s)://xxx.xxx.xxx.xxx:xxx`，以防请求死循环；如使用Docker，可以使用形如`docker run -p 80:8080 nondanee/unblockneteasemusic -f xx.xx.xx.xx`的命令直接拉起容器使用，不需要加`-p 80`参数
 >
 > **Android 客户端下修改 hosts 无法直接使用**，原因和解决方法详见[云音乐安卓又搞事啦](https://jixun.moe/post/netease-android-hosts-bypass/)，[安卓免 root 绕过网易云音乐 IP 限制](https://jixun.moe/post/android-block-netease-without-root/)
 


### PR DESCRIPTION
在单机容器部署时指定IP不方便：用`CMD`可以直接拉起容器并传入参数。