### PR TITLE
解决QQ音乐无法获取MP3格式音源的问题

### DIFF
--- a/provider/qq.js
+++ b/provider/qq.js
@@ -59,30 +59,9 @@ const ticket = id => {
 	// .catch(() => insure().qq.ticket())
 
 	let url =
-		'https://u.y.qq.com/cgi-bin/musicu.fcg?data=' +
-		encodeURIComponent(JSON.stringify({
-			// req: {
-			// 	method: 'GetCdnDispatch',
-			// 	module: 'CDN.SrfCdnDispatchServer',
-			// 	param: {
-			// 		calltype: 0,
-			// 		guid: '7332953645',
-			// 		userip: ''
-			// 	}
-			// },
-			req_0: {
-				module: 'vkey.GetVkeyServer',
-				method: 'CgiGetVkey',
-				param: {
-					guid: '7332953645',
-					loginflag: 1,
-					songmid: [id],
-					songtype: [0],
-					uin: '0',
-					platform: '20'
-				}
-			}
-		}))
+        'http://c.y.qq.com/base/fcgi-bin/fcg_music_express_mobile3.fcg?format=json&platform=yqq&needNewCode=0&cid=205361747&uin=0&guid=0' +
+        `&songmid=${id}&filename=M500${id}.mp3`
+    const sip = 'http://mobileoc.music.tc.qq.com/'
 
 	return request('GET', url)
 	.then(response => response.json())
@@ -91,7 +70,9 @@ const ticket = id => {
 		// 	jsonBody.req_0.data.midurlinfo[0].vkey ||
 		// 	(jsonBody.req_0.data.testfile2g.match(/vkey=(\w+)/) || [])[1]
 		// return vkey || Promise.reject()
-		return jsonBody.req_0.data.sip[0] + jsonBody.req_0.data.midurlinfo[0].purl
+		let filename = jsonBody.data.items[0].filename
+        let vkey = jsonBody.data.items[0].vkey
+        return sip + `${filename}?guid=0&uin=0&vkey=${vkey}`
 	})
 	// .catch(() => insure().qq.ticket())
 }


### PR DESCRIPTION
替换QQ音源的API，可以获取MP3格式的音源了，音质比 `.m4a` 格式应该会有所提升。不过数字版权问题依然无解，而且这个API比较玄学，比如周董新歌 `《说好不哭》` 可以正常拿到 `vkey` ，其它很多如 `《告白气球》` 却不可以，搞不懂鹅厂的做法。。。
ps：我不是很懂js，照着原来的代码改的。没测试，作者merge之前先测试下有无bug~