### PR TITLE
add clientlog.music.163.com to hook.target.host

### DIFF
--- a/src/hook.js
+++ b/src/hook.js
@@ -28,12 +28,12 @@ hook.target.host = new Set([
 	'interface3.music.163.com',
 	'apm.music.163.com',
 	'apm3.music.163.com',
+	'clientlog.music.163.com',
+	'clientlog3.music.163.com'
 	// 'mam.netease.com',
 	// 'api.iplay.163.com', // look living
 	// 'ac.dun.163yun.com',
 	// 'crash.163.com',
-	// 'clientlog.music.163.com',
-	// 'clientlog3.music.163.com'
 ])
 
 hook.target.path = new Set([


### PR DESCRIPTION
according to #423, not works on android using transparent proxy in some cases.