### PR TITLE
fix req.url

### DIFF
--- a/src/hook.js
+++ b/src/hook.js
@@ -67,9 +67,17 @@ hook.target.path = new Set([
 	'/api/v1/discovery/recommend/songs'
 ])
 
+const domainList = [
+	'music.163.com', 
+	'music.126.net',
+	'iplay.163.com',
+	'look.163.com',
+	'y.163.com',
+]
+
 hook.request.before = ctx => {
 	const {req} = ctx
-	req.url = (req.url.startsWith('http://') ? '' : (req.socket.encrypted ? 'https:' : 'http:') + '//' + req.headers.host) + req.url
+	req.url = (req.url.startsWith('http://') ? '' : (req.socket.encrypted ? 'https:' : 'http:') + '//' + (domainList.some(domain => (req.headers.host || '').endsWith(domain)) ? req.headers.host : null)) + req.url
 	const url = parse(req.url)
 	if ([url.hostname, req.headers.host].some(host => host.includes('music.163.com'))) ctx.decision = 'proxy'
 	if ([url.hostname, req.headers.host].some(host => hook.target.host.has(host)) && req.method == 'POST' && (url.path == '/api/linux/forward' || url.path.startsWith('/eapi/'))) {
@@ -94,7 +102,7 @@ hook.request.before = ctx => {
 					netease.path = data[0]
 					netease.param = JSON.parse(data[1])
 				}
-				netease.path = netease.path.replace(/\/\d*$/, '')
+				netease.path = netease.path.replace(/\/\d*$/, '') 
 				ctx.netease = netease
 				// console.log(netease.path, netease.param)
 

--- a/src/hook.js
+++ b/src/hook.js
@@ -69,7 +69,7 @@ hook.target.path = new Set([
 
 hook.request.before = ctx => {
 	const {req} = ctx
-	req.url = (req.url.startsWith('http://') ? '' : (req.socket.encrypted ? 'https:' : 'http:') + '//' + (['music.163.com', 'music.126.net'].some(domain => (req.headers.host || '').endsWith(domain)) ? req.headers.host : null)) + req.url
+	req.url = (req.url.startsWith('http://') ? '' : (req.socket.encrypted ? 'https:' : 'http:') + '//' + req.headers.host) + req.url
 	const url = parse(req.url)
 	if ([url.hostname, req.headers.host].some(host => host.includes('music.163.com'))) ctx.decision = 'proxy'
 	if ([url.hostname, req.headers.host].some(host => hook.target.host.has(host)) && req.method == 'POST' && (url.path == '/api/linux/forward' || url.path.startsWith('/eapi/'))) {

--- a/src/hook.js
+++ b/src/hook.js
@@ -102,7 +102,7 @@ hook.request.before = ctx => {
 					netease.path = data[0]
 					netease.param = JSON.parse(data[1])
 				}
-				netease.path = netease.path.replace(/\/\d*$/, '') 
+				netease.path = netease.path.replace(/\/\d*$/, '')
 				ctx.netease = netease
 				// console.log(netease.path, netease.param)
 


### PR DESCRIPTION
Fix the problem: When using iptables matching ip on the router to redirect ip to unblockmusic, the problem that some domain names cannot be accessed.
For example: iplay.163.com

test url: https://iplay.163.com/live?id=1

fix before:
```
GET MITM > (ssl) https://null/live?id=1
```

fix after:
```
GET MITM > (ssl) https://iplay.163.com/live?id=1
```

**If you want to block other domain names from being accessed through unblockmusic, you should enable "--strict".**