### PR TITLE
cert/key added in environment variables

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -157,9 +157,11 @@ const proxy = {
 	}
 }
 
+const cert = process.env.cert || path.join(__dirname, '..', 'server.crt')
+const key = process.env.key || path.join(__dirname, '..', 'server.key')
 const options = {
-	key: fs.readFileSync(path.join(__dirname, '..', 'server.key')),
-	cert: fs.readFileSync(path.join(__dirname, '..', 'server.crt'))
+	key: fs.readFileSync(key),
+	cert: fs.readFileSync(cert)
 }
 
 const server = {


### PR DESCRIPTION
使用自签证书的话docker可以通过虚拟映射 -v 使用证书
npx @nondanee/unblockneteasemusic 没有参数可以替换证书
只能下载项目后替换证书

通过设置环境变量
export cert = /certpath
export key = /keypath
npx @nondanee/unblockneteasemusic
就可以使用自签证书了，不用替换文件，只需设置两个环境变量