### PR TITLE
Use non-zero exit code on error.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -83,4 +83,7 @@ Promise.all([httpdns, httpdns2].map(query => query(target.join(','))).concat(tar
 	if (port[0]) server.http.listen(port[0], address).once('listening', () => log(0))
 	if (port[1]) server.https.listen(port[1], address).once('listening', () => log(1))
 })
-.catch(error => console.log(error))
+.catch(error => {
+	console.log(error)
+	process.exit(1)
+})


### PR DESCRIPTION
I'm using a systemd service to start this project. Setting exit codes correctly makes it easier to integrate with service managers.
