### PR TITLE
feat(find): support add acquired music information

### DIFF
--- a/src/provider/match.js
+++ b/src/provider/match.js
@@ -13,10 +13,10 @@ const provider = {
 	youtube: require('./youtube')
 }
 
-const match = (id, source) => {
+const match = (id, source, data) => {
 	let meta = {}
 	const candidate = (source || global.source || ['qq', 'kuwo', 'migu']).filter(name => name in provider)
-	return find(id)
+	return find(id, data)
 	.then(info => {
 		meta = info
 		return Promise.all(candidate.map(name => provider[name].check(info).catch(() => {})))


### PR DESCRIPTION
允许传入已经获取到的音乐信息可以解决两个问题：

1. 避免重复发起请求（第三方客户端接入时其实已经能拿到当前id的音乐信息）
2. 目前的请求方式因为没有携带 real-ip 等请求头，在多次请求后会被限制